### PR TITLE
[1.7.10] Fix/headless connect classic forge (Crucible)

### DIFF
--- a/1_16/src/main/java/me/earth/headlessmc/mc/mixins/MixinMinecraft.java
+++ b/1_16/src/main/java/me/earth/headlessmc/mc/mixins/MixinMinecraft.java
@@ -20,7 +20,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.client.main.GameConfig;
 import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraft.client.multiplayer.ServerAddress;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.resources.language.I18n;
@@ -99,13 +98,12 @@ public abstract class MixinMinecraft extends MixinBlockableEventLoop implements 
     @Override
     public void connect(String ip, int port) {
         this.disconnect();
-        ServerAddress address = ServerAddress.parseString(ip + ":" + port);
         setScreen(
             new ConnectScreen(
                 new TitleScreen(),
                 net.minecraft.client.Minecraft.class.cast(this),
                 new ServerData(
-                    I18n.get("selectServer.defaultName"), address.toString(), false)));
+                    I18n.get("selectServer.defaultName"), ip + ":" + port, false)));
     }
 
     @Override

--- a/1_7_10/src/main/java/me/earth/headlessmc/mc/mixins/MixinMinecraft.java
+++ b/1_7_10/src/main/java/me/earth/headlessmc/mc/mixins/MixinMinecraft.java
@@ -15,6 +15,7 @@ import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.client.gui.GuiMainMenu;
 import net.minecraft.client.gui.GuiMultiplayer;
 import net.minecraft.client.multiplayer.GuiConnecting;
+import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.util.Session;
 import org.spongepowered.asm.mixin.Final;
@@ -96,11 +97,23 @@ public abstract class MixinMinecraft implements Minecraft {
     @Override
     public void connect(String ip, int port) {
         this.disconnect();
-        this.displayGuiScreen(
-            new GuiConnecting(new GuiMainMenu(),
-                              net.minecraft.client.Minecraft.class.cast(this),
-                              ip,
-                              port));
+        GuiMainMenu menu = new GuiMainMenu();
+        // On Forge, route the join through FMLClientHandler.connectToServer: it shows the same
+        // connecting screen AND initializes FMLClientHandler.playClientBlock - the latch the FML
+        // mod-list handshake awaits after login. A hand-built GuiConnecting leaves that latch null,
+        // so the handshake NPEs in waitForPlayClient() right after S02PacketLoginSuccess. Forge is
+        // not on this shared source set's compile classpath (only the vanilla client is), so call it
+        // reflectively; fall back to the vanilla connect when off Forge (e.g. Fabric).
+        try {
+            Class<?> fml = Class.forName("cpw.mods.fml.client.FMLClientHandler");
+            Class<?> guiScreen = Class.forName("net.minecraft.client.gui.GuiScreen");
+            Object handler = fml.getMethod("instance").invoke(null);
+            fml.getMethod("connectToServer", guiScreen, ServerData.class)
+               .invoke(handler, menu, new ServerData("headlessmc", ip + ":" + port));
+        } catch (Throwable t) {
+            this.displayGuiScreen(new GuiConnecting(
+                menu, net.minecraft.client.Minecraft.class.cast(this), ip, port));
+        }
     }
 
     @Override


### PR DESCRIPTION
On Forge, route the join through FMLClientHandler.connectToServer: it shows the same
connecting screen AND initializes FMLClientHandler.playClientBlock - the latch the FML
mod-list handshake awaits after login. A hand-built GuiConnecting leaves that latch null,
so the handshake NPEs in waitForPlayClient() right after S02PacketLoginSuccess. Forge is
not on this shared source set's compile classpath (only the vanilla client is), so call it
reflectively; fall back to the vanilla connect when off Forge (e.g. Fabric).